### PR TITLE
Canonical json

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
       - uses: actions/checkout@v3
       - name: Add GitHub Deployment

--- a/src/components/app/App.tsx
+++ b/src/components/app/App.tsx
@@ -2,7 +2,6 @@ import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
-import useLocalState from "../../hooks/UseLocalState.tsx";
 import { GameConfiguration } from "@buf/broomy_mediocre.community_timostamm-protobuf-ts/mediocre/configuration/v1beta/game_pb";
 import { v4 as uuid } from "uuid";
 import {
@@ -18,6 +17,7 @@ import { getRandomTimestamps } from "../video/GrabFrames.ts";
 import { Outlet } from "react-router-dom";
 import { AppLayout } from "./AppLayout.tsx";
 import { ResultsProviders } from "../providers/transform-results/ResultsProvider.tsx";
+import useLocalMessage from "../../hooks/UseLocalMessage.tsx";
 
 function getDefaultGameConfiguration(): GameConfiguration {
   return {
@@ -49,16 +49,16 @@ function getDefaultTestConfiguration(
 }
 
 function App() {
-  const [gameConfiguration, setGameConfiguration] =
-    useLocalState<GameConfiguration>(
-      getDefaultGameConfiguration(),
-      "game-configuration",
-    );
-  const [testConfiguration, setTestConfiguration] =
-    useLocalState<TestConfiguration>(
-      getDefaultTestConfiguration(gameConfiguration),
-      "test-configuration",
-    );
+  const [gameConfiguration, setGameConfiguration] = useLocalMessage(
+    getDefaultGameConfiguration(),
+    GameConfiguration,
+    "game-configuration",
+  );
+  const [testConfiguration, setTestConfiguration] = useLocalMessage(
+    getDefaultTestConfiguration(gameConfiguration),
+    TestConfiguration,
+    "test-configuration",
+  );
 
   return (
     <AppProviders>

--- a/src/hooks/UseLocalMessage.tsx
+++ b/src/hooks/UseLocalMessage.tsx
@@ -1,0 +1,23 @@
+import { IMessageType } from "@protobuf-ts/runtime";
+import useLocalState from "./UseLocalState.tsx";
+import { JsonValue } from "@protobuf-ts/runtime/build/types/json-typings";
+
+function useLocalMessage<T extends object>(
+  defaultValue: T,
+  messageType: IMessageType<T>,
+  key: string,
+) {
+  const defaultJsonValue = messageType.toJson(defaultValue);
+  const [value, setValue] = useLocalState<JsonValue>(defaultJsonValue, key);
+
+  const setMessage = (message: T) => {
+    const value = messageType.toJson(message);
+    setValue(value);
+  };
+
+  const message = messageType.fromJson(value);
+
+  return [message, setMessage] as const;
+}
+
+export default useLocalMessage;


### PR DESCRIPTION
Previously I was saving/loading the configuration as a string representation of the protobuf-ts objects, rather than as canonical protobuf json format. Protobuf-TS representation is slightly different, including things like extra nesting for `oneof` fields, and the representation cannot be used to communicate with grpc servers, so canonical json format is better in every way here.